### PR TITLE
MySQL container configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 setuptools.setup(
     name='testcontainers',
     packages=setuptools.find_packages(exclude=['tests']),
-    version='2.1.0',
+    version='2.1.1',
     description=('Library provides lightweight, throwaway '
                  'instances of common databases, '
                  'Selenium web browsers, or anything else that can '

--- a/testcontainers/mysql.py
+++ b/testcontainers/mysql.py
@@ -17,20 +17,25 @@ from testcontainers.core.generic import DbContainer
 
 class MySqlContainer(DbContainer):
     MYSQL_USER = environ.get("MYSQL_USER", "test")
-
-    if MYSQL_USER != 'root':
-        MYSQL_ROOT_PASSWORD = environ.get("MYSQL_ROOT_PASSWORD", "test")
-        MYSQL_PASSWORD = environ.get("MYSQL_PASSWORD", "test")
-    else:
-        MYSQL_ROOT_PASSWORD = environ.get("MYSQL_ROOT_PASSWORD", environ.get("MYSQL_PASSWORD", "test"))
-        MYSQL_PASSWORD = MYSQL_ROOT_PASSWORD
-
+    MYSQL_ROOT_PASSWORD = environ.get("MYSQL_ROOT_PASSWORD", "test")
+    MYSQL_PASSWORD = environ.get("MYSQL_PASSWORD", "test")
     MYSQL_DATABASE = environ.get("MYSQL_DATABASE", "test")
 
-    def __init__(self, image="mysql:latest"):
+    def __init__(self, image="mysql:latest", **kwargs):
         super(MySqlContainer, self).__init__(image)
         self.port_to_expose = 3306
         self.with_exposed_ports(self.port_to_expose)
+        if 'MYSQL_USER' in kwargs:
+            self.MYSQL_USER = kwargs['MYSQL_USER']
+        if 'MYSQL_ROOT_PASSWORD' in kwargs:
+            self.MYSQL_ROOT_PASSWORD = kwargs['MYSQL_ROOT_PASSWORD']
+        if 'MYSQL_PASSWORD' in kwargs:
+            self.MYSQL_PASSWORD = kwargs['MYSQL_PASSWORD']
+        if 'MYSQL_DATABASE' in kwargs:
+            self.MYSQL_DATABASE = kwargs['MYSQL_DATABASE']
+
+        if self.MYSQL_USER == 'root':
+            self.MYSQL_ROOT_PASSWORD = self.MYSQL_PASSWORD
 
     def _configure(self):
         self.with_env("MYSQL_ROOT_PASSWORD", self.MYSQL_ROOT_PASSWORD)

--- a/testcontainers/mysql.py
+++ b/testcontainers/mysql.py
@@ -16,10 +16,16 @@ from testcontainers.core.generic import DbContainer
 
 
 class MySqlContainer(DbContainer):
-    MYSQL_ROOT_PASSWORD = environ.get("MYSQL_ROOT_PASSWORD", "test")
-    MYSQL_DATABASE = environ.get("MYSQL_DATABASE", "test")
     MYSQL_USER = environ.get("MYSQL_USER", "test")
-    MYSQL_PASSWORD = environ.get("MYSQL_PASSWORD", "test")
+
+    if MYSQL_USER != 'root':
+        MYSQL_ROOT_PASSWORD = environ.get("MYSQL_ROOT_PASSWORD", "test")
+        MYSQL_PASSWORD = environ.get("MYSQL_PASSWORD", "test")
+    else:
+        MYSQL_ROOT_PASSWORD = environ.get("MYSQL_ROOT_PASSWORD", environ.get("MYSQL_PASSWORD", "test"))
+        MYSQL_PASSWORD = MYSQL_ROOT_PASSWORD
+
+    MYSQL_DATABASE = environ.get("MYSQL_DATABASE", "test")
 
     def __init__(self, image="mysql:latest"):
         super(MySqlContainer, self).__init__(image)
@@ -29,8 +35,10 @@ class MySqlContainer(DbContainer):
     def _configure(self):
         self.with_env("MYSQL_ROOT_PASSWORD", self.MYSQL_ROOT_PASSWORD)
         self.with_env("MYSQL_DATABASE", self.MYSQL_DATABASE)
-        self.with_env("MYSQL_USER", self.MYSQL_USER)
-        self.with_env("MYSQL_PASSWORD", self.MYSQL_PASSWORD)
+
+        if self.MYSQL_USER != "root":
+            self.with_env("MYSQL_USER", self.MYSQL_USER)
+            self.with_env("MYSQL_PASSWORD", self.MYSQL_PASSWORD)
 
     def get_connection_url(self):
         return super()._create_connection_url(dialect="mysql+pymysql",

--- a/tests/test_db_containers.py
+++ b/tests/test_db_containers.py
@@ -26,7 +26,7 @@ def test_docker_run_postgress():
 
 
 def test_docker_run_mariadb():
-    mariadb_container = MariaDbContainer("mariadb:latest")
+    mariadb_container = MariaDbContainer("mariadb:10.2.9")
     with mariadb_container as mariadb:
         e = sqlalchemy.create_engine(mariadb.get_connection_url())
         result = e.execute("select version()")


### PR DESCRIPTION
I've got 2 test cases with MySQL:
1) Testing under the user "root"
2) Testing without specifying a database (our application creates DB by himself)

Now it's possible to use MySQL container in both of 2 these cases