### PR TITLE
Remove container specific import from __init__.py

### DIFF
--- a/testcontainers/__init__.py
+++ b/testcontainers/__init__.py
@@ -1,6 +1,2 @@
-from testcontainers.selenium import BrowserWebDriverContainer
-from testcontainers.mysql import MySqlContainer
-from testcontainers.postgres import PostgresContainer
-from testcontainers.oracle import OracleDbContainer
 from testcontainers.core.generic import GenericContainer
 from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for


### PR DESCRIPTION
Fix for https://github.com/SergeyPirogov/testcontainers-python/issues/13